### PR TITLE
Fixed API base URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "myorb/onboardiq",
+    "name": "dmitrymomot/onboardiq",
     "description": "php onboardiq api wrapper",
     "minimum-stability": "stable",
     "license": "MIT",
@@ -7,6 +7,10 @@
         {
             "name": "Alex Shalaiev",
             "email": "itdep24@gmail.com"
+        },
+        {
+            "name": "Dmitry Momot",
+            "email": "mail@dmomot.com"
         }
     ],
     "require": {

--- a/src/OnboardIQ.php
+++ b/src/OnboardIQ.php
@@ -10,7 +10,7 @@ use GuzzleHttp\Client;
  */
 class OnboardIQ
 {
-    const API_URL = 'https://www.onboardiq.com/api';
+    const API_URL = 'https://api.fountain.com';
     const API_VERSION = 'v2';
     const API_URI = 'applicants';
 


### PR DESCRIPTION
OnboardIq was renamed to Fountain, so API base URL was changed too.